### PR TITLE
Keep trying to connect if there's no connection at first

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ readme = open('README.md').read()
 
 setup(
     name='udacidrone',
-    version='0.3.0',
+    version='0.3.1',
     description="Drone API for Udacity's Flying Car Nanodegree",
     long_description=readme,
     packages=find_packages(exclude=('tests*',)),

--- a/udacidrone/connection/mavlink_connection.py
+++ b/udacidrone/connection/mavlink_connection.py
@@ -52,7 +52,13 @@ class MavlinkConnection(connection.Connection):
 
         # create the connection
         if device is not "":
-            self._master = mavutil.mavlink_connection(device)
+            while True:
+                try:
+                    self._master = mavutil.mavlink_connection(device)
+                    break
+                except Exception as e:
+                    print("Retrying connection in 1 second ...")
+                    time.sleep(1)
 
         # set up any of the threading, as needed
         self._out_msg_queue = queue.Queue()  # a queue for sending data between threads


### PR DESCRIPTION
This allows the script to be run prior to the simulator server starting. https://github.com/udacity/fcnd-issue-reports/issues/57.

NOTE: The mavlink connection `mavutil.mavlink_connection` has the arguments: `autoreconnect` and `retries`. Using these options didn't work hence the presented solution.