### PR TITLE
Catching exception when time attribute is missing

### DIFF
--- a/udacidrone/drone.py
+++ b/udacidrone/drone.py
@@ -114,10 +114,13 @@ class Drone(object):
         def on_message_receive(msg_name, msg):
             """Sorts incoming messages, updates the drone state variables and runs callbacks"""
             # print('Message received', msg_name, msg)
-            if (((msg.time - self._message_time) > 0.0)):
-                self._message_frequency = 1.0 / (msg.time - self._message_time)
-                self._message_time = msg.time
-                self._time_bias = msg.time - time.time()
+            try:
+                if (((msg.time - self._message_time) > 0.0)):
+                    self._message_frequency = 1.0 / (msg.time - self._message_time)
+                    self._message_time = msg.time
+                    self._time_bias = msg.time - time.time()
+            except AttributeError:
+                pass
 
             if msg_name == MsgID.CONNECTION_CLOSED:
                 self.stop()


### PR DESCRIPTION
Hi, I enjoyed doing the course but ran into an issue as described here - https://knowledge.udacity.com/questions/12507

```
Sending waypoints to simulator ...
Traceback (most recent call last):
File "/anaconda/envs/fcnd/lib/python3.6/site-packages/udacidrone/connection/connection.py", line 88, in notify_message_listeners
fn(name, msg)
File "/anaconda/envs/fcnd/lib/python3.6/site-packages/udacidrone/drone.py", line 117, in on_message_receive
if (((msg.time - self._message_time) > 0.0)):
AttributeError: 'int' object has no attribute 'time'
```

This is the workaround I found and I think it will be a helpful fix for all other students. Let me know what do you think about this PR