### PR TITLE
Upgrade deps to work with python 3.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,14 @@ setup(
     # TODO: Add team email
     author_email='',
     install_requires=[
-        'numpy>=1.12',
-        'future==0.16.0',
-        'lxml==4.1.1',
-        'pymavlink==2.2.8',
+        'numpy>=1.21',
+        'future==0.18.2',
+        'lxml==4.9.2',
+        'pymavlink==2.4.41',
         'utm==0.4',
-        'websockets==4.0.1',
+        'websockets>=10.0',
         'cflib>=0.1.6',
-    ] + (['uvloop==0.9.1'] if platform.system() is not 'Windows' else []),
+    ] + (['uvloop==0.17.0'] if platform.system() is not 'Windows' else []),
     tests_require=['flake8', 'pytest'],
     keywords='drone api udacity flying car quadrotor',
     license='MIT License',
@@ -30,7 +30,7 @@ setup(
         'Intended Audience :: Developers',
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.10',
     ],
     # yapf
 )


### PR DESCRIPTION
Related issue: https://knowledge.udacity.com/questions/1028179

Current deps versions dont work with https://github.com/udacity/FCND-Term1-Starter-Kit on mac with m1 chip due to python 3.6.

Here I've upgraded deps to work python 3.10.13.
All the drone commands from backyard flyer project worked well on my mac with M1 Pro chip.
Drone was able to take off, move, etc.


Linked FCND-Term1-Starter-Kit pr:
https://github.com/udacity/FCND-Term1-Starter-Kit/pull/8